### PR TITLE
Removed duplicate values in template & added version updating

### DIFF
--- a/viaq-template/com.redhat.viaq-template.asciidoc
+++ b/viaq-template/com.redhat.viaq-template.asciidoc
@@ -113,6 +113,20 @@ type: string
 Field contains whitespace-delimited tags. Tagging is configured on normalizers/collectors. Please note that this field is analyzed and not an array since rsyslog doesn't play well with JSON lists
 
 
+==== file
+
+type: string
+
+File something.
+
+
+==== offset
+
+type: string
+
+TODO.
+
+
 === pipeline_metadata Fields
 
 Metadata related to ViaQ log collection pipeline. Everything about log collector, normalizers goes here. Data in this subgroup is stored for troublehsooting purposes mostly.
@@ -438,20 +452,6 @@ TODO
 
 Mapping specifically for openstack. Inherits all the fields from __default__ _type of the documents in this mapping should be openstack
 
-
-
-==== file
-
-type: string
-
-File something.
-
-
-==== offset
-
-type: string
-
-TODO.
 
 
 [[exported-fields-openstack]]

--- a/viaq-template/com.redhat.viaq-template.template.json
+++ b/viaq-template/com.redhat.viaq-template.template.json
@@ -2,12 +2,8 @@
   "aliases": {},
   "mappings": {
     "_default_": {
-      "_all": {
-        "enabled": true,
-        "omit_norms": true
-      },
       "_meta": {
-        "version": "2016-02-23.0"
+        "version": "2016.03.10.0"
       },
       "date_detection": false,
       "dynamic_templates": [
@@ -60,6 +56,19 @@
         "CEE": {
           "type": "object"
         },
+        "file": {
+          "fields": {
+            "raw": {
+              "ignore_above": 256,
+              "index": "not_analyzed",
+              "type": "string"
+            }
+          },
+          "norms": {
+            "enabled": true
+          },
+          "type": "string"
+        },
         "geoip": {
           "dynamic": true,
           "properties": {
@@ -97,6 +106,19 @@
         "message": {
           "norms": {
             "enabled": false
+          },
+          "type": "string"
+        },
+        "offset": {
+          "fields": {
+            "raw": {
+              "ignore_above": 256,
+              "index": "not_analyzed",
+              "type": "string"
+            }
+          },
+          "norms": {
+            "enabled": true
           },
           "type": "string"
         },
@@ -309,99 +331,11 @@
       }
     },
     "openstack": {
-      "_all": {
-        "enabled": true,
-        "omit_norms": true
-      },
       "_meta": {
-        "version": "2016-02-23.0"
+        "version": "2016.03.10.0"
       },
       "date_detection": false,
       "properties": {
-        "@timestamp": {
-          "fields": {
-            "raw": {
-              "ignore_above": 256,
-              "index": "not_analyzed",
-              "type": "string"
-            }
-          },
-          "format": "yyyy-MM-dd'T'HH:mm:ss.SSSSSSZ||yyyy-MM-dd'T'HH:mm:ssZ||dateOptionalTime",
-          "type": "date"
-        },
-        "@version": {
-          "index": "not_analyzed",
-          "type": "string"
-        },
-        "CEE": {
-          "type": "object"
-        },
-        "file": {
-          "fields": {
-            "raw": {
-              "ignore_above": 256,
-              "index": "not_analyzed",
-              "type": "string"
-            }
-          },
-          "norms": {
-            "enabled": true
-          },
-          "type": "string"
-        },
-        "geoip": {
-          "dynamic": true,
-          "properties": {
-            "location": {
-              "type": "geo_point"
-            }
-          },
-          "type": "object"
-        },
-        "hostname": {
-          "index": "not_analyzed",
-          "type": "string"
-        },
-        "ipaddr4": {
-          "fields": {
-            "raw": {
-              "ignore_above": 256,
-              "index": "not_analyzed",
-              "type": "string"
-            }
-          },
-          "norms": {
-            "enabled": false
-          },
-          "type": "ip"
-        },
-        "ipaddr6": {
-          "index": "not_analyzed",
-          "type": "string"
-        },
-        "level": {
-          "index": "not_analyzed",
-          "type": "string"
-        },
-        "message": {
-          "norms": {
-            "enabled": false
-          },
-          "type": "string"
-        },
-        "offset": {
-          "fields": {
-            "raw": {
-              "ignore_above": 256,
-              "index": "not_analyzed",
-              "type": "string"
-            }
-          },
-          "norms": {
-            "enabled": true
-          },
-          "type": "string"
-        },
         "openstack": {
           "properties": {
             "class": {
@@ -444,212 +378,6 @@
               "type": "string"
             }
           }
-        },
-        "pid": {
-          "index": "not_analyzed",
-          "type": "string"
-        },
-        "pipeline_metadata": {
-          "properties": {
-            "inputname": {
-              "index": "not_analyzed",
-              "type": "string"
-            },
-            "original_raw_message": {
-              "index": "not_analyzed",
-              "type": "string"
-            },
-            "timegenerated": {
-              "format": "yyyy-MM-dd'T'HH:mm:ss.SSSSSSZ||yyyy-MM-dd'T'HH:mm:ssZ||dateOptionalTime",
-              "type": "date"
-            },
-            "trace": {
-              "analyzer": "whitespace",
-              "type": "string"
-            }
-          }
-        },
-        "rsyslog": {
-          "properties": {
-            "facility": {
-              "index": "not_analyzed",
-              "type": "string"
-            },
-            "protocol-version": {
-              "index": "not_analyzed",
-              "type": "string"
-            },
-            "structured-data": {
-              "norms": {
-                "enabled": false
-              },
-              "type": "string"
-            }
-          }
-        },
-        "service": {
-          "index": "not_analyzed",
-          "type": "string"
-        },
-        "systemd": {
-          "properties": {
-            "k": {
-              "properties": {
-                "KERNEL_DEVICE": {
-                  "index": "not_analyzed",
-                  "type": "string"
-                },
-                "KERNEL_SUBSYSTEM": {
-                  "index": "not_analyzed",
-                  "type": "string"
-                },
-                "UDEV_DEVLINK": {
-                  "index": "not_analyzed",
-                  "type": "string"
-                },
-                "UDEV_DEVNODE": {
-                  "index": "not_analyzed",
-                  "type": "string"
-                },
-                "UDEV_SYSNAME": {
-                  "index": "not_analyzed",
-                  "type": "string"
-                }
-              }
-            },
-            "t": {
-              "properties": {
-                "AUDIT_LOGINUID": {
-                  "index": "not_analyzed",
-                  "type": "string"
-                },
-                "AUDIT_SESSION": {
-                  "index": "not_analyzed",
-                  "type": "string"
-                },
-                "BOOT_ID": {
-                  "index": "not_analyzed",
-                  "type": "string"
-                },
-                "CAP_EFFECTIVE": {
-                  "index": "not_analyzed",
-                  "type": "string"
-                },
-                "CMDLINE": {
-                  "norms": {
-                    "enabled": false
-                  },
-                  "type": "string"
-                },
-                "COMM": {
-                  "index": "not_analyzed",
-                  "type": "string"
-                },
-                "EXE": {
-                  "norms": {
-                    "enabled": false
-                  },
-                  "type": "string"
-                },
-                "GID": {
-                  "index": "not_analyzed",
-                  "type": "string"
-                },
-                "HOSTNAME": {
-                  "index": "not_analyzed",
-                  "type": "string"
-                },
-                "MACHINE_ID": {
-                  "index": "not_analyzed",
-                  "type": "string"
-                },
-                "PID": {
-                  "index": "not_analyzed",
-                  "type": "string"
-                },
-                "SELINUX_CONTEXT": {
-                  "index": "not_analyzed",
-                  "type": "string"
-                },
-                "SOURCE_REALTIME_TIMESTAMP": {
-                  "index": "not_analyzed",
-                  "type": "string"
-                },
-                "SYSTEMD_CGROUP": {
-                  "index": "not_analyzed",
-                  "type": "string"
-                },
-                "SYSTEMD_OWNER_UID": {
-                  "index": "not_analyzed",
-                  "type": "string"
-                },
-                "SYSTEMD_SESSION": {
-                  "index": "not_analyzed",
-                  "type": "string"
-                },
-                "SYSTEMD_SLICE": {
-                  "index": "not_analyzed",
-                  "type": "string"
-                },
-                "SYSTEMD_UNIT": {
-                  "index": "not_analyzed",
-                  "type": "string"
-                },
-                "SYSTEMD_USER_UNIT": {
-                  "index": "not_analyzed",
-                  "type": "string"
-                },
-                "TRANSPORT": {
-                  "index": "not_analyzed",
-                  "type": "string"
-                },
-                "UID": {
-                  "index": "not_analyzed",
-                  "type": "string"
-                }
-              }
-            },
-            "u": {
-              "properties": {
-                "CODE_FILE": {
-                  "norms": {
-                    "enabled": false
-                  },
-                  "type": "string"
-                },
-                "CODE_FUNCTION": {
-                  "index": "not_analyzed",
-                  "type": "string"
-                },
-                "CODE_LINE": {
-                  "index": "not_analyzed",
-                  "type": "string"
-                },
-                "ERRNO": {
-                  "index": "not_analyzed",
-                  "type": "string"
-                },
-                "MESSAGE_ID": {
-                  "index": "not_analyzed",
-                  "type": "string"
-                },
-                "RESULT": {
-                  "norms": {
-                    "enabled": false
-                  },
-                  "type": "string"
-                },
-                "UNIT": {
-                  "index": "not_analyzed",
-                  "type": "string"
-                }
-              }
-            }
-          }
-        },
-        "tags": {
-          "analyzer": "whitespace",
-          "type": "string"
         }
       }
     }
@@ -658,5 +386,5 @@
   "settings": {
     "index.refresh_interval": "5s"
   },
-  "template": "viaq-*"
+  "template": "v2016.03.10.0-viaq-*"
 }

--- a/viaq-template/fields.yml
+++ b/viaq-template/fields.yml
@@ -1,4 +1,4 @@
-version: 1.0
+version: 2016.03.10.0
 
 defaults:
   type: string
@@ -106,6 +106,30 @@ _default_:
       description: >
         Field contains whitespace-delimited tags. Tagging is configured on normalizers/collectors.
         Please note that this field is analyzed and not an array since rsyslog doesn't play well with JSON lists
+
+    - name: file
+      type: string
+      description: >
+        File something.
+      norms:
+        enabled: True
+      fields:
+        - name: raw
+          type: string
+          index: not_analyzed
+          ignore_above: 256
+
+    - name: offset
+      type: string
+      description: >
+        TODO.
+      norms:
+        enabled: True
+      fields:
+        - name: raw
+          type: string
+          index: not_analyzed
+          ignore_above: 256
 
     - pipeline_metadata:
       type: group
@@ -394,30 +418,6 @@ openstack:
     Mapping specifically for openstack. Inherits all the fields from __default__
     _type of the documents in this mapping should be openstack
   fields:
-    - name: file
-      type: string
-      description: >
-        File something.
-      norms:
-        enabled: True
-      fields:
-        - name: raw
-          type: string
-          index: not_analyzed
-          ignore_above: 256
-
-    - name: offset
-      type: string
-      description: >
-        TODO.
-      norms:
-        enabled: True
-      fields:
-        - name: raw
-          type: string
-          index: not_analyzed
-          ignore_above: 256
-
     - name: openstack
       type: group
       description: >

--- a/viaq-template/skeleton.json
+++ b/viaq-template/skeleton.json
@@ -2,12 +2,8 @@
     "aliases": {},
     "mappings": {
         "_default_": {
-            "_all": {
-                "enabled": true,
-                "omit_norms": true
-            },
             "_meta": {
-                "version": "2016-02-23.0"
+                "version": "<version>"
             },
             "date_detection": false,
             "dynamic_templates": [
@@ -48,5 +44,5 @@
     "settings": {
         "index.refresh_interval": "5s"
     },
-    "template": "viaq-*"
+    "template": "v<version>-viaq-*"
 }


### PR DESCRIPTION
@portante please check.
Updated the script/skeleton to automatically add version to _meta and to index name. Current version is added to fields.yml.

Removed _all from the skeleton.

Derived values are no longer duplicated in the JSON template.
'file' and 'offset' fields moved to the _default_
