### PR TITLE
RFC: Scribery mappings

### DIFF
--- a/namespaces/aushape.yml
+++ b/namespaces/aushape.yml
@@ -1,0 +1,55 @@
+
+namespace:
+  name: aushape
+  type: group
+  description: >
+    Audit events converted with aushape
+    For more information please see
+    https://github.com/Scribery/aushape
+  fields:
+  - name: serial
+    type: long
+    description: >
+      Audit event serial number
+  - name: time
+    type: date
+    description: >
+      Audit event timestamp
+  - name: node
+    type: string
+    description: >
+      Name of the host where the audit event occurred
+  - name: error
+    type: string
+    description: >
+      The error aushape encountered while converting the event
+  - name: trimmed
+    type: string
+    description: >
+      An array of JSONPath expressions relative to the event object,
+      specifying objects/arrays with (some) contents removed as the result of
+      event size limiting. Empty string means event itself. Empty array means
+      trimming occurred at unspecified objects/arrays.
+  - name: text
+    type: string
+    index: analyzed
+    doc_values: false
+    description: >
+      An array log record strings representing the original audit event
+  - name: data
+    type: group
+    description: >
+      Parsed audit event data
+    fields:
+    - name: avc
+      type: nested
+    - name: execve
+      type: string
+      index: analyzed
+      doc_values: false
+    - name: netfilter_cfg
+      type: nested
+    - name: obj_pid
+      type: nested
+    - name: path
+      type: nested

--- a/namespaces/tlog.yml
+++ b/namespaces/tlog.yml
@@ -1,0 +1,61 @@
+
+namespace:
+  name: tlog
+  type: group
+  description: >
+    Tlog terminal I/O recording messages
+    For more information please see
+    https://github.com/Scribery/tlog
+  fields:
+  - name: ver
+    type: long
+    description: >
+      Message format version number
+  - name: host
+    type: string
+    description: >
+      Name of the host recording was made on
+  - name: user
+    type: string
+    description: >
+      Recorded user name
+  - name: term
+    type: string
+    description: >
+      Terminal type name
+  - name: session
+    type: long
+    description: >
+      Audit session ID of the recorded session
+  - name: id
+    type: long
+    description: >
+      ID of the message within the session
+  - name: pos
+    type: long
+    description: >
+      Message position in the session, milliseconds
+  - name: timing
+    type: string
+    description: >
+      Distribution of this message's events in time
+  - name: in_txt
+    type: string
+    index: analyzed
+    doc_values: false
+    description: >
+      Input text with invalid characters scrubbed
+  - name: in_bin
+    type: short
+    description: >
+      Scrubbed invalid input characters as bytes
+  - name: out_txt
+    type: string
+    index: analyzed
+    doc_values: false
+    description: >
+      Output text with invalid characters scrubbed
+  - name: out_bin
+    type: short
+    description: >
+      Scrubbed invalid output characters as bytes

--- a/scripts/generate_template.py
+++ b/scripts/generate_template.py
@@ -217,7 +217,7 @@ def process_leaf(field, defaults, groupname=None):
 
     res = {}
     if field.get("type") in ["string", "date", "ip", "integer", "long",
-                             "boolean", "nested"]:
+                             "short", "byte", "boolean", "nested"]:
         res[field["name"]] = working_field.copy()
         res[field.get("name")].update(process_subleaf(field, defaults))
     elif field.get("type") == "object":
@@ -267,7 +267,7 @@ def process_leaf_index_pattern(field, defaults, groupname):
     # https://github.com/elastic/kibana/blob/master/src/ui/public/index_patterns/_field_types.js
     if field.get("type") in ["string", "date", "ip", "boolean"]:
         fieldtype = field.get("type")
-    elif field.get("type") in ["integer", "long", "float"]:
+    elif field.get("type") in ["integer", "long", "short", "byte", "float"]:
         fieldtype = "number"
     elif field.get("type") == "object":
         if "geo_point" == field.get("object_struct", {}).get("properties", {}).get("location", {}).get("type", ''):

--- a/scripts/generate_template.py
+++ b/scripts/generate_template.py
@@ -217,15 +217,15 @@ def process_leaf(field, defaults, groupname=None):
 
     res = {}
     if field.get("type") in ["string", "date", "ip", "integer", "long",
-                             "short", "byte", "boolean", "nested"]:
+                             "short", "byte", "boolean"]:
         res[field["name"]] = working_field.copy()
         res[field.get("name")].update(process_subleaf(field, defaults))
-    elif field.get("type") == "object":
+    elif field.get("type") in ["object", "nested"]:
         if "object_struct" in field:
             res[field["name"]] = working_field["object_struct"].copy()
         else:
             res[field["name"]] = {}
-        res[field["name"]]["type"] = "object"
+        res[field["name"]]["type"] = field.get("type")
     elif field.get("type") == "float":
         res[field["name"]] = {
             "type": "float",

--- a/templates/openshift/template.yml
+++ b/templates/openshift/template.yml
@@ -12,4 +12,6 @@ namespaces:
   - kubernetes.yml
   - docker.yml
   - pipeline_metadata.yml
+  - aushape.yml
+  - tlog.yml
 #  - openshift/app_log.yml

--- a/templates/skeleton.json
+++ b/templates/skeleton.json
@@ -35,6 +35,32 @@
                         "match": "*",
                         "match_mapping_type": "string"
                     }
+                },
+                {
+                    "aushape_generic_nested_fields": {
+                        "path_match": "aushape.data.*.*.*",
+                        "mapping": {
+                            "type": "string",
+                            "index": "analyzed"
+                        }
+                    }
+                },
+                {
+                    "aushape_generic_fields": {
+                        "path_match": "aushape.data.*.*",
+                        "mapping": {
+                            "type": "string",
+                            "index": "analyzed"
+                        }
+                    }
+                },
+                {
+                    "aushape_generic_records": {
+                        "path_match": "aushape.data.*",
+                        "mapping": {
+                            "type": "object"
+                        }
+                    }
                 }
             ],
             "properties": {}


### PR DESCRIPTION
This is a rough draft of what might be required to incorporate the Scribery (Session Recording) project data into common logging data model and pipeline.

Basically, I'm adding two new namespaces: `tlog` and `aushape`. I'm adding support for `byte` and `short` types to `generate_template.py` to support the `short` type currently used by tlog mapping. I'm also adding better support for `nested` type, similarly to `object` type, although I'm not at all sure I'm doing it right. The code was pretty difficult to understand for me.

If we are to automate this, we'll likely need to support specifying any necessary dynamic templates in namespaces, as aushape currently needs them and will likely still need them for quite a while, if not forever. Manually (or even automatically) pasting them into the skeleton would be burdensome in the long term. We can probably do that by prefixing namespace dynamic template names with the namespace name and an underscore, while also prefixing the patterns inside the templates somehow.

I think that making the namespaces more modular in general will ease integration with any other future log sources, and might even allow outside contributions without much help from our side.

I abandoned the idea of using the integration-tests repo for testing for now, because it is quite ad-hoc, poorly documented, and difficult to expand at this moment. However, I would dearly like to see the ability to test against your setup, with my additions to the Elasticsearch mappings, Kibana index patterns, and transformations in Fluentd.

As such, I was testing against my own setup of Fluentd, which was pulling logs from Journald, filtering out aushape and tlog data, putting them under "namespaces" and shoving that to Elasticsearch - a very limited test. Here's the relevant configuration snippet:

    <source>
        @type systemd
        pos_file "/home/nkondras/var/log/fluent/journal.pos"
        tag systemd
    </source>

    <match systemd>
        @type rewrite_tag_filter
        rewriterule1 _UID ^0$ systemd.root
        rewriterule2 _UID ^987$ systemd.tlog
        rewriterule3 MESSAGE ^ systemd.other
    </match>

    <match systemd.root>
        @type rewrite_tag_filter
        rewriterule1 _COMM ^aushape$ systemd.root.aushape
        rewriterule2 MESSAGE ^ systemd.root.other
    </match>

    <match systemd.tlog>
        @type rewrite_tag_filter
        rewriterule1 _COMM ^tlog-rec$ systemd.tlog.tlog-rec
        rewriterule2 MESSAGE ^ systemd.tlog.other
    </match>

    <filter systemd.root.aushape>
        @type parser
        format json
        key_name MESSAGE
        reserve_data true
        hash_value_field aushape
        time_parse false
    </filter>

    <filter systemd.tlog.tlog-rec>
        @type parser
        format json
        key_name MESSAGE
        reserve_data true
        hash_value_field tlog
        time_parse false
    </filter>

    <match systemd.{root.aushape,tlog.tlog-rec}>
        @type copy
        <store>
            @type stdout
        </store>
        <store>
            @type elasticsearch
            logstash_format false
            host localhost
            port 9200
            index_name viaq
            type_name viaq
        </store>
    </match>

    <match **>
        @type null
    </match>

Next I would like to try feeding aushape and tlog logs through the official ViaQ pipeline setup, if it exists, with the changes I need, have dynamic templates supported for namespaces and invent a way to sync tlog and aushape schema changes automatically, or with the least manual work.

Please take a look and tell me what I'm doing wrong and what you would like to change in my approach.

Thank you.
