### PR TITLE
raw fields in index-patterns; more kubernetes fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.index-pattern.json
 *.template.json
 *~
+templates/*/*.asciidoc

--- a/namespaces/_default_.yml
+++ b/namespaces/_default_.yml
@@ -1,4 +1,4 @@
-version: 2017.06.06.0
+version: 2017.07.05.0
 
 field_defaults:
   type: string

--- a/namespaces/kubernetes.yml
+++ b/namespaces/kubernetes.yml
@@ -45,6 +45,17 @@ namespace:
     description: >
       Kubernetes Master URL
 
+  - name: container_name
+    type: string
+    norms:
+      enabled: true
+    description: >
+      The name of the container in Kubernetes.
+    fields:
+      - name: raw
+        ignore_above: 256
+        type: string
+
   - name: annotations
     type: group
     description: >
@@ -57,6 +68,32 @@ namespace:
       Each label name is a subfield of labels field.
       Each label name is de-dotted: dots in the name are replaced with
       underscores.
+    fields:
+      - name: deployment
+        type: string
+        example: logging-kibana-3
+        description: >
+          The deployment associated with this Kubernetes object
+      - name: deploymentconfig
+        type: string
+        example: logging-kibana
+        description: >
+          The deploymentconfig associated with this Kubernetes object
+        fields:
+          - name: raw
+            ignore_above: 64
+            type: string
+      - name: component
+        type: string
+        example: kibana
+        description: >
+          The component associated with this Kubernetes object
+      - name: provider
+        type: string
+        example: openshift
+        description: >
+          The provider associated with this Kubernetes object
+
 
 doc_sections:
   - ["pod_log", "Openshift logging metadata"]

--- a/scripts/generate_template.py
+++ b/scripts/generate_template.py
@@ -212,7 +212,10 @@ def traverse_group_section_index_pattern(group, defaults, leaf_handler, groupnam
                 subgroupname = None
             else:
                 subgroupname = group.get("name", None)
-            if field.get("type") == "group":
+            if field.get("type") == "group" or "fields" in field:
+                if not field.get("type") == "group": # assume leaf
+                    out_field = leaf_handler(field, defaults, subgroupname)
+                    fields.append(out_field)
                 more_fields = traverse_group_section_index_pattern(field, defaults, leaf_handler, subgroupname)
                 fields.extend(more_fields)
             else:


### PR DESCRIPTION
Add support for the raw fields in the index-patterns, so that they
can be used in saved searches and dashboards. For example,
add an index pattern field for `@timestamp.raw`.
Add the following kubernetes fields:
- container_name
- container_name.raw
- labels
-- deploymentconfig and deploymentconfig.raw
-- deployment
-- component
-- provider
@portante @jcantrill @t0ffel PTAL