### PR TITLE
Remove include_in_all from ovirt/collectd template

### DIFF
--- a/namespaces/collectd.yml
+++ b/namespaces/collectd.yml
@@ -6,43 +6,36 @@ namespace:
   fields:
   - name: interval
     type: float
-    include_in_all: false
     description: >
       Collectd's interval.
 
   - name: plugin
     type: keyword
-    include_in_all: false
     description: >
       Collectd's plugin.
 
   - name: plugin_instance
     type: keyword
-    include_in_all: false
     description: >
       Collectd's plugin_instance.
 
   - name: type_instance
     type: keyword
-    include_in_all: false
     description: >
       Collectd's type_instance.
 
   - name: type
     type: keyword
-    include_in_all: false
     description: >
       Collectd's type.
 
   - name: dstypes
     type: keyword
-    include_in_all: false
     description: >
       Collectd's dstypes.
 
   - name: processes
     type: group
-    include_in_all: false
     description: >
       Corresponds to collectd's processes plugin.
     fields:
@@ -161,7 +154,6 @@ namespace:
     type: group
     description: >
       Corresponds to collectd's disk plugin.
-    include_in_all: false
     fields:
     - name: disk_merged
       type: group
@@ -247,7 +239,6 @@ namespace:
     type: group
     description: >
       Corresponds to collectd's interface plugin.
-    include_in_all: false
     fields:
     - name: if_octets
       type: group
@@ -311,7 +302,6 @@ namespace:
 
   - name: virt
     type: group
-    include_in_all: false
     description: >
       Corresponds to collectd's virt plugin.
     fields:
@@ -422,7 +412,6 @@ namespace:
 
   - name: cpu
     type: group
-    include_in_all: false
     description: >
       Corresponds to collectd's CPU plugin.
     fields:
@@ -433,7 +422,6 @@ namespace:
 
   - name: df
     type: group
-    include_in_all: false
     description: >
       Corresponds to collectd's df plugin.
     fields:
@@ -450,7 +438,6 @@ namespace:
 
   - name: entropy
     type: group
-    include_in_all: false
     description: >
       Corresponds to collectd's entropy plugin.
     fields:
@@ -464,7 +451,6 @@ namespace:
     type: group
     description: >
       Corresponds to collectd's nfs plugin.
-    include_in_all: false
     fields:
 
     - name: nfs_procedure
@@ -476,7 +462,6 @@ namespace:
     type: group
     description: >
       Corresponds to collectd's memory plugin.
-    include_in_all: false
     fields:
 
     - name: memory
@@ -493,7 +478,6 @@ namespace:
     type: group
     description: >
       Corresponds to collectd's swap plugin.
-    include_in_all: false
     fields:
 
     - name: swap
@@ -510,7 +494,6 @@ namespace:
     type: group
     description: >
       Corresponds to collectd's load plugin.
-    include_in_all: false
     fields:
     - name: load
       type: group
@@ -536,7 +519,6 @@ namespace:
     type: group
     description: >
       Corresponds to collectd's aggregation plugin.
-    include_in_all: false
     fields:
 
     - name: percent
@@ -548,7 +530,6 @@ namespace:
     type: group
     description: >
       Corresponds to collectd's statsd plugin.
-    include_in_all: false
     fields:
 
     - name: host_cpu
@@ -790,7 +771,6 @@ namespace:
     type: group
     description: >
       Corresponds to collectd's postgresql plugin.
-    include_in_all: false
     fields:
 
     - name: pg_n_tup_g

--- a/scripts/compare_against_released_templates_test.py
+++ b/scripts/compare_against_released_templates_test.py
@@ -133,6 +133,14 @@ class CompareAgainstReleasedTemplatesTestCase(helper.CommonTestSupport):
         if 'aushape' in released_data["mappings"]["_default_"]["properties"]:
             released_data["mappings"]["_default_"]["properties"]["aushape"]["properties"]["error"]["index"] = "analyzed"
             released_data["mappings"]["_default_"]["properties"]["aushape"]["properties"]["error"]["doc_values"] = False
+
+        # We need to remove the `include_in_all` from downloaded model because this setting has been removed.
+        # https://github.com/ViaQ/elasticsearch-templates/issues/102
+        if 'collectd' in released_data["mappings"]["_default_"]["properties"]:
+            for metric_key in released_data["mappings"]["_default_"]["properties"]["collectd"]["properties"].keys():
+                metric = released_data["mappings"]["_default_"]["properties"]["collectd"]["properties"][metric_key]
+                if 'include_in_all' in metric:
+                    metric.pop('include_in_all')
         # ======================
 
         released_index_template = self._sort(released_data)


### PR DESCRIPTION
We are removing setting `include_in_all` from ovirt/collectd template
because this template disables the `_all` field. Hence the include in
all feature does not make any sense (no fields can included or excluded
if there is no `_all` field).

Closes #102