### PR TITLE
Bump to 2019.06.24.0

### DIFF
--- a/namespaces/_default_.yml
+++ b/namespaces/_default_.yml
@@ -1,4 +1,4 @@
-version: 2018.09.20.0
+version: 2019.06.24.0
 
 field_defaults:
   type: keyword


### PR DESCRIPTION
Prepare for the new release (the last one before ES 6.x support)