### PR TITLE
Update documentation for viaq_index_name_doc field

### DIFF
--- a/namespaces/_default_.yml
+++ b/namespaces/_default_.yml
@@ -190,7 +190,12 @@ _index_type_:
         
     - name: viaq_index_name
       type: keyword
-      example: project.my-cool-project-in-lab04.748e92c2-70d7-11e9-b387-000d3af2d83b.2019.05.09
+      example: container.app-write
       description: |
-        Index name in which this message will be stored within the Elasticsearch.
-        The value of this field is generated based on the source of the message. 
+        For Elasticsearch 6.x and later this is a name of a write index alias. The value depends on a log type
+        of this message. Detailed documentation is found at
+        https://github.com/openshift/enhancements/blob/master/enhancements/cluster-logging/cluster-logging-es-rollover-data-design.md#data-model
+        
+        For Elasticsearch 5.x and earlier an index name in which this message will be stored within the Elasticsearch.
+        The value of this field is generated based on the source of the message. Example of the value
+        is 'project.my-cool-project-in-lab04.748e92c2-70d7-11e9-b387-000d3af2d83b.2019.05.09'.


### PR DESCRIPTION
This is to address review comments from https://github.com/openshift/origin-aggregated-logging/pull/1807

Updated documentation for field `viaq_index_name_doc` yields the following asciidoc source:

```asciidoc
==== viaq_index_name

type: keyword

example: container.app-000001

For Elasticsearch 6.x and later this is a name of a write index alias. The value depends on a log type
of this message. Detailed documentation is found at
https://github.com/openshift/enhancements/blob/master/enhancements/cluster-logging/cluster-logging-es-rollover-data-design.md#data-model

For Elasticsearch 5.x and earlier an index name in which this message will be stored within the Elasticsearch.
The value of this field is generated based on the source of the message. Example of the value
is 'project.my-cool-project-in-lab04.748e92c2-70d7-11e9-b387-000d3af2d83b.2019.05.09'.
```