### PR TITLE
WIP: Initial stab at generating public docs for data model.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 *.index-pattern.json
 *.template.json
 *~
-templates/*/*.asciidoc
+templates/*/*.adoc
 scripts/*.pyc
 scripts/__pycache__/*
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ List of currently supported ES versions can be find in [scripts/supported_versio
 
 The idea is that all the input file templates and data are formatted according to the latest supported ES version and
 scripts handle backward data and format conversions for older ES versions. As part of unit testing the generated data
-is compared to released common data files (automatically downloaded from GitHub during tests). 
+is compared to released common data files (automatically downloaded from GitHub during tests).
 
 # Generating documentation
 
@@ -51,13 +51,13 @@ Use the makefile in the [templates/](templates) folder.
 
 Alternatively, run the following command: python ./scripts/generate_template.py (path to template in templates/) namespaces/ --doc.
 
-The generated file looks like "xxx.asciidoc".
+The generated file looks like "xxx.adoc".
 
 # Viewing the documentation
 
 Install the asciidoc viewer in web browser.
 
-Open the local path to the asciidoc file "xxx.asciidoc" in your browser.
+Open the local path to the asciidoc file "xxx.adoc" in your browser.
 
 # Releasing a new version of the data model
 
@@ -71,7 +71,7 @@ Create a new release tag in repo and push it into GitHub.
 ```shell script
 $ git tag -a 0.0.24 -m "Release 0.0.24"
 
-# We can check the tag is attached to the latest commit now 
+# We can check the tag is attached to the latest commit now
 $ git log --oneline -n 2
 c16dc2c (HEAD -> master, tag: 0.0.24, origin/master, origin/HEAD) Fix index patterns
 39d0b71 (tag: 0.0.23) Update model & Bump to 2020.01.23
@@ -80,7 +80,7 @@ c16dc2c (HEAD -> master, tag: 0.0.24, origin/master, origin/HEAD) Fix index patt
 $ git push origin --tags
 Total 0 (delta 0), reused 0 (delta 0)
 To github.com:ViaQ/elasticsearch-templates.git
- * [new tag]         0.0.24 -> 0.0.24 
+ * [new tag]         0.0.24 -> 0.0.24
 ```
 Create a new release in GitHub project release.
 - create a new release draft from newly created tag

--- a/logging/Makefile
+++ b/logging/Makefile
@@ -1,0 +1,7 @@
+.PHONY: all clean docs
+
+all:
+	python3 ../scripts/generate_template.py public-docs.yml ../namespaces/ --docs --public
+
+clean:
+	rm *.json *.adoc

--- a/logging/public-docs.yml
+++ b/logging/public-docs.yml
@@ -1,0 +1,11 @@
+skeleton_path: skeleton.json
+skeleton_index_pattern_path: ../templates/skeleton-index-pattern.json
+
+elasticsearch_template:
+  name: openshift-cluster-logging
+  index_pattern_old_model: "project.*"
+  index_pattern: [ "app*" ]
+  order: 10
+
+namespaces:
+  - kubernetes.yml

--- a/namespaces/_default_.yml
+++ b/namespaces/_default_.yml
@@ -9,6 +9,7 @@ field_defaults:
 _index_type_:
   type: group
   name: "Default"
+  public: true
   description: |
     The top level fields are common to every application, and may be present in every record.
     For the Elasticsearch template, this is what populates the actual mappings
@@ -22,6 +23,7 @@ _index_type_:
 
   fields:
     - name: "@timestamp"
+      public: true
       type: date
       format: yyyy-MM-dd HH:mm:ss,SSSZ||yyyy-MM-dd'T'HH:mm:ss.SSSSSSZ||yyyy-MM-dd'T'HH:mm:ssZ||dateOptionalTime
       example: 2015-01-24T14:06:05.071Z
@@ -45,6 +47,7 @@ _index_type_:
             type: geo_point
 
     - name: hostname
+      public: true
       type: keyword
       description: >
         FQDN of the entity generating the original payload.  This field is a
@@ -53,6 +56,7 @@ _index_type_:
         namespace itself, and the collector or normalizer knows that.
 
     - name: ipaddr4
+      public: true
       type: ip
       description: >
         IP address v4 of the source server. Can be an array.
@@ -62,11 +66,13 @@ _index_type_:
           type: keyword
 
     - name: ipaddr6
+      public: true
       type: ip
       description: >
         IP address v6 of the source server (if available). Can be an array.
 
     - name: level
+      public: true
       type: keyword
       example: info
       description: |
@@ -89,6 +95,7 @@ _index_type_:
         CRITICAL -> crit, ERROR -> err, ...., DEBUG -> debug
 
     - name: message
+      public: true
       type: text
       index: true
       doc_values: false
@@ -99,6 +106,7 @@ _index_type_:
       norms: false
 
     - name: pid
+      public: true
       type: keyword
       description: >
         This is the process ID of the logging entity, if available.
@@ -144,6 +152,7 @@ _index_type_:
         new version of the log file (rotation).
 
     - name: namespace_name
+      public: true
       type: keyword
       example: my-cool-project-in-lab04
       doc_values: false
@@ -162,6 +171,7 @@ _index_type_:
         See also namespace_uuid.
 
     - name: namespace_uuid
+      public: true
       type: keyword
       example: 82f13a8e-882a-4344-b103-f0a6f30fd218
       description: |
@@ -187,7 +197,7 @@ _index_type_:
         store or application other than Elasticsearch, but you still need
         to correlate data with the data stored in Elasticsearch, this field
         will give you the exact document corresponding to the record.
-        
+
     - name: viaq_index_name
       type: keyword
       example: container.app-write
@@ -195,7 +205,7 @@ _index_type_:
         For Elasticsearch 6.x and later this is a name of a write index alias. The value depends on a log type
         of this message. Detailed documentation is found at
         https://github.com/openshift/enhancements/blob/master/enhancements/cluster-logging/cluster-logging-es-rollover-data-design.md#data-model
-        
+
         For Elasticsearch 5.x and earlier an index name in which this message will be stored within the Elasticsearch.
         The value of this field is generated based on the source of the message. Example of the value
         is 'project.my-cool-project-in-lab04.748e92c2-70d7-11e9-b387-000d3af2d83b.2019.05.09'.

--- a/namespaces/kubernetes.yml
+++ b/namespaces/kubernetes.yml
@@ -1,35 +1,41 @@
 
 namespace:
   name: kubernetes
+  public: true
   type: group
   description: >
     Namespace for kubernetes-specific metadata
   fields:
   - name: pod_name
+    public: true
     type: keyword
     norms: true
     description: >
       The name of the pod
 
   - name: pod_id
+    public: true
     type: keyword
     norms: true
     description: >
       Kubernetes ID of the pod.
 
   - name: namespace_name
+    public: true
     type: keyword
     norms: true
     description: >
       The name of the namespace in Kubernetes.
 
   - name: namespace_id
+    public: true
     type: keyword
     norms: true
     description: >
       ID of the namespace in Kubernetes.
 
   - name: host
+    public: true
     type: keyword
     norms: true
     description: >
@@ -41,6 +47,7 @@ namespace:
       Kubernetes Master URL
 
   - name: container_name
+    public: true
     type: text
     doc_values: false
     norms: true
@@ -52,24 +59,28 @@ namespace:
         type: keyword
 
   - name: annotations
+    public: true
     type: group
     description: >
-      Annotations associated with the OpenShift object
+      Annotations associated with the Kubernetes object
 
   - name: labels
+    public: true
     type: group
     description: >
-      Labels attached to the OpenShift object
+      Labels attached to the Kubernetes object
       Each label name is a subfield of labels field.
       Each label name is de-dotted: dots in the name are replaced with
       underscores.
     fields:
       - name: deployment
+        public: true
         type: keyword
         example: logging-kibana-3
         description: >
           The deployment associated with this Kubernetes object
       - name: deploymentconfig
+        public: true
         type: keyword
         example: logging-kibana
         description: >
@@ -91,107 +102,127 @@ namespace:
 
   - name: event
     type: group
+    public: true
     description: >
       The kubernetes event obtained from kubernetes master API
       The event is already JSON object and as whole nested under kubernetes field
       This description should loosely follow 'type Event' in https://github.com/kubernetes/kubernetes/blob/master/pkg/api/types.go
     fields:
       - name: verb
+        public: true
         type: keyword
         example: ADDED
         description: >
           The type of event, can be ADDED, MODIFIED, DELETED
       - name: metadata
+        public: true
         type: group
         description: >
           Information related to the location and time of the event creation
         fields:
           - name: name
+            public: true
             type: keyword
             example: java-mainclass-1.14d888a4cfc24890
             description: >
               Name of the object that triggered the event creation
           - name: namespace
+            public: true
             type: keyword
             example: default
             description: >
               The name of the namespace which induced the event
               It differs from namespace_name, which will be in case of every event the 'eventrouter'
           - name: selfLink
+            public: true
             type: keyword
             example: /api/v1/namespaces/javaj/events/java-mainclass-1.14d888a4cfc24890
             description: >
               Link to the event itself
           - name: uid
+            public: true
             type: keyword
             example: d828ac69-7b58-11e7-9cf5-5254002f560c
             description: >
               Event's unique ID
           - name: resourceVersion
+            public: true
             type: integer
             example: 311987
             description: >
               String that identifies the server's internal version of the event that can be used by clients to determine when objects have changed
       - name: involvedObject
+        public: true
         type: group
         description: >
           Description of the object involved in the event creation
         fields:
           - name: kind
+            public: true
             type: keyword
             example: ReplicationController
             description: >
               Type of the object
           - name: namespace
+            public: true
             type: keyword
             example: default
             description: >
               The name of the namespace in which the object triggered the event
               In case this event is not triggered by a pod then it differs from kubernetes.namespace_name, which will be in case of every event eventrouter's namespace
           - name: name
+            public: true
             type: keyword
             example: java-mainclass-1
             description: >
               Name of the object that triggered the event
           - name: uid
+            public: true
             type: keyword
             example: e6bff941-76a8-11e7-8193-5254002f560c
             description: >
               Object's unique ID
           - name: apiVersion
+            public: true
             type: keyword
             example: v1
             description: >
               Version of kubernetes master API
           - name: resourceVersion
+            public: true
             type: keyword
             example: 308882
             description: >
               String that identifies the server's internal version of the pod triggering the event that can be used by clients to determine when objects have changed
       - name: reason
+        public: true
         type: keyword
         example: SuccessfulCreate
         description: >
-          Short, machine understandable string that gives the reason for this event being generated 
+          Short, machine understandable string that gives the reason for this event being generated
       - name: source_component
+        public: true
         type: keyword
         example: replication-controller
         description: >
           Component which reported this event
       - name: firstTimestamp
+        public: true
         type: date
         format: yyyy-MM-dd HH:mm:ss,SSSZ||yyyy-MM-dd'T'HH:mm:ss.SSSSSSZ||yyyy-MM-dd'T'HH:mm:ssZ||dateOptionalTime
         example: 2017-08-07T10:11:57Z
         description: >
           The time at which the event was first recorded
       - name: count
+        public: true
         type: integer
         example: 1
         description: >
           The number of times this event has occurred
       - name: type
+        public: true
         type: keyword
-        example: Normal 
+        example: Normal
         description: >
           Type of this event (Normal, Warning), new types could be added in the future
 

--- a/scripts/generate_field_docs.py
+++ b/scripts/generate_field_docs.py
@@ -73,19 +73,19 @@ grouped in the following categories:
 
     # fields file is empty
     if docs is None:
-        print("fields.yml file is empty. fields.asciidoc cannot be generated.")
+        print("fields.yml file is empty. fields.adoc cannot be generated.")
         return
 
     # If no sections are defined, docs can't be generated
     if "doc_sections" not in docs.keys():
-        print("doc_sections is not defined in fields.yml. fields.asciidoc cannot be generated.")
+        print("doc_sections is not defined in fields.yml. fields.adoc cannot be generated.")
         return
 
     sections = docs["doc_sections"]
 
     # Check if sections is define
     if sections is None:
-        print("No doc_sections are defined in fields.yml. fields.asciidoc cannot be generated.")
+        print("No doc_sections are defined in fields.yml. fields.adoc cannot be generated.")
         return
 
     for doc, _ in sections:
@@ -116,7 +116,7 @@ if __name__ == "__main__":
     template_name = sys.argv[2]
 
     f_input = open(template_path + "/fields.yml", 'r')
-    f_output = open(template_path + "/" + template_name + ".asciidoc", 'wb')
+    f_output = open(template_path + "/" + template_name + ".adoc", 'wb')
 
     try:
         fields_to_asciidoc(f_input, f_output, template_name.title())

--- a/scripts/generate_template.py
+++ b/scripts/generate_template.py
@@ -365,7 +365,7 @@ This file is generated! See scripts/generate_template.py --docs
 [[exported-fields]]
 == Exported Fields
 
-These are the fields exported by the logging system and available for searching
+    These are the fields exported by the logging system and available for searching
 from Elasticsearch and Kibana.  Use the full, dotted field name when searching.
 For example, for an Elasticsearch /_search URL, to look for a Kubernetes pod name,
 use `/_search/q=kubernetes.pod_name:name-of-my-pod`
@@ -387,6 +387,9 @@ The fields are grouped in the following categories:
 
 
 def document_fields(output, section, hier_path=[]):
+
+    if args.public and not section.get('public'):
+        return
 
     if section['name'] == 'Default':
         str_path = u''
@@ -418,6 +421,8 @@ def document_fields(output, section, hier_path=[]):
 
 
 def document_field(output, field, str_path):
+    if args.public and not field.get('public'):
+        return
 
     if len(str_path) == 0:
         path = field['name']
@@ -448,6 +453,8 @@ def parse_args():
                    help='Path to directory with namespace definitions')
     p.add_argument('--docs', action='store_true', default=False,
                    help='Generate field documentation')
+    p.add_argument('--public', action='store_true', default=False,
+                   help='Generate only public field documentation')
 
     # Do not call parse_args() on parser yet so that we can use it in unittests
     return p
@@ -460,7 +467,7 @@ if __name__ == '__main__':
         template_definition = yaml.load(input_template, Loader=yaml.FullLoader)
 
     if args.docs:
-        with io.open('{0[elasticsearch_template][name]}.asciidoc'.format(
+        with io.open('{0[elasticsearch_template][name]}.adoc'.format(
                 template_definition), mode='w', encoding='utf8') as output:
             object_types_to_asciidoc(template_definition, output,
                                      args.namespaces_dir)

--- a/templates/Makefile
+++ b/templates/Makefile
@@ -2,7 +2,8 @@ TEMPLATE_NAME = com.redhat.viaq-openshift
 
 .PHONY: all templates index_pattern
 
-INDEX_PATTERN_DIRS = openshift,collectd_metrics
+INDEX_PATTERN_DIRS = openshift
+
 
 all: templates index_pattern
 

--- a/templates/ci_model/Makefile
+++ b/templates/ci_model/Makefile
@@ -6,4 +6,4 @@ all:
 	python3 ../../scripts/generate_template.py template.yml ../../namespaces/
 
 clean:
-	rm *.json *.asciidoc
+	rm *.json *.adoc

--- a/templates/collectd_metrics/Makefile
+++ b/templates/collectd_metrics/Makefile
@@ -4,7 +4,7 @@ all: docs
 	python3 ../../scripts/generate_template.py template.yml ../../namespaces/
 
 clean:
-	rm *.json *.asciidoc
+	rm *.json *.adoc
 
 docs:
 	python3 ../../scripts/generate_template.py template.yml ../../namespaces/ --docs

--- a/templates/fedora_ci/Makefile
+++ b/templates/fedora_ci/Makefile
@@ -6,4 +6,4 @@ all:
 	python3 ../../scripts/generate_template.py template.yml ../../namespaces/
 
 clean:
-	rm *.json *.asciidoc
+	rm *.json *.adoc

--- a/templates/foreman/Makefile
+++ b/templates/foreman/Makefile
@@ -4,7 +4,7 @@ all: docs
 	python3 ../../scripts/generate_template.py template.yml ../../namespaces/
 
 clean:
-	rm *.json *.asciidoc
+	rm *.json *.adoc
 
 docs:
 	python3 ../../scripts/generate_template.py template.yml ../../namespaces/ --docs

--- a/templates/openshift/Makefile
+++ b/templates/openshift/Makefile
@@ -5,7 +5,7 @@ all: docs
 	python3 ../../scripts/generate_template.py template-operations.yml ../../namespaces/
 
 clean:
-	rm *.json *.asciidoc
+	rm *.json *.adoc
 
 docs:
 	python3 ../../scripts/generate_template.py template-project.yml ../../namespaces/ --docs

--- a/templates/test/Makefile
+++ b/templates/test/Makefile
@@ -4,7 +4,7 @@ all: docs
 	python3 ../../scripts/generate_template.py template-test.yml ../../namespaces/
 
 clean:
-	rm *.json *.asciidoc
+	rm *.json *.adoc
 
 docs:
 	python3 ../../scripts/generate_template.py template-test.yml ../../namespaces/ --docs


### PR DESCRIPTION
Done:
- Changed doc suffix from .asciidoc to .adoc  recommended suffix.
- logging/ subdir with Makefile to generate public docs.
- Added `public: true` to field definitions that are definitely public (conservative)
- Added --public flag to generator, generate only fields with `public: true`

Yet to do:
- Full review of public/private fields
- Include generated output in a separate doc template
- Allow doc author better control of format, look, doc properties
- Move TOC out of the generation script, let asciidoc tools do that.

/cc @rolfe
/cc @lukas