### PR TITLE
LOG-3419: Kibana Filtering not working with filters that have / in them

### DIFF
--- a/namespaces/kubernetes.yml
+++ b/namespaces/kubernetes.yml
@@ -55,16 +55,6 @@ namespace:
     type: group
     description: >
       Annotations associated with the OpenShift object
-  - name: labels
-    type: nested
-    description: >
-      Labels attached to the OpenShift object
-      Each label name is a subfield of labels field.
-  - name: namespace_labels
-    type: nested
-    description: >
-      Labels attached to the namespace in which the openshift object is deployed
-      Each label name is a subfield of labels field.
   - name: event
     type: group
     description: >


### PR DESCRIPTION
## Description
This PR addresses issues with filtering on `kubernetes.labels` and `kubernetes.namespace_labels` in Kibana. This removes those fields in the `kubernetes.yml` file.

cc: @jcantrill 

## Relevant Jira issues:
1. https://issues.redhat.com/browse/LOG-3419
2. https://issues.redhat.com/browse/LOG-3439